### PR TITLE
feat(Makefile): Build libgit dependency statically

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "third_party/libgit2/git2go"]
+	path = third_party/libgit2/git2go
+	url = https://github.com/libgit2/git2go.git

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -29,6 +29,8 @@ builds:
     goarch:
       - amd64
     binary: '{{ .ProjectName }}_v{{ .Version }}_{{ .Env.API_VERSION }}_{{ .Os }}_{{ .Arch }}'
+    hooks:
+      pre: make git2go
   -
     id: linux-builds
     mod_timestamp: '{{ .CommitTimestamp }}'
@@ -47,6 +49,8 @@ builds:
       - goos: linux
         goarch: amd64
     binary: '{{ .ProjectName }}_v{{ .Version }}_{{ .Env.API_VERSION }}_{{ .Os }}_{{ .Arch }}'
+    hooks:
+      pre: make git2go
 archives:
 - format: zip
   files:

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -13,7 +13,7 @@ GO_VERSION  ?= 1.20
 .PHONY: dev
 
 build: git2go
-	@go build -o ${BINARY}
+	@go build -tags static -buildvcs=false -o ${BINARY}
 
 dev: build
 	@mkdir -p ~/.packer.d/plugins/

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -5,9 +5,14 @@ COUNT?=1
 TEST?=$(shell go list ./...)
 HASHICORP_PACKER_PLUGIN_SDK_VERSION?=$(shell go list -m github.com/hashicorp/packer-plugin-sdk | cut -d " " -f2)
 
+CMAKE       ?= cmake
+WORKDIR     ?= $(CURDIR)
+VENDORDIR   ?= $(WORKDIR)/third_party
+GO_VERSION  ?= 1.20
+
 .PHONY: dev
 
-build:
+build: git2go
 	@go build -o ${BINARY}
 
 dev: build
@@ -32,3 +37,32 @@ testacc: dev
 
 generate: install-packer-sdc
 	@go generate ./...
+
+.PHONY: git2go
+git2go: $(VENDORDIR)/libgit2/git2go/static-build/install/lib/pkgconfig/libgit2.pc
+	@go install -tags static github.com/libgit2/git2go/v31/...
+
+$(VENDORDIR)/libgit2/git2go/static-build/install/lib/pkgconfig/libgit2.pc: $(VENDORDIR)/libgit2/git2go/vendor/libgit2
+	@mkdir -p $(VENDORDIR)/libgit2/git2go/static-build/build
+	@mkdir -p $(VENDORDIR)/libgit2/git2go/static-build/install
+	(cd $(VENDORDIR)/libgit2/git2go/static-build/build && $(CMAKE) \
+		-DTHREADSAFE=ON \
+		-DBUILD_CLAR=OFF \
+		-DBUILD_SHARED_LIBS=OFF \
+		-DREGEX_BACKEND=builtin \
+		-DUSE_BUNDLED_ZLIB=ON \
+		-DUSE_HTTPS=ON \
+		-DUSE_SSH=ON \
+		-DCMAKE_C_FLAGS=-fPIC \
+		-DCMAKE_BUILD_TYPE="RelWithDebInfo" \
+		-DCMAKE_INSTALL_PREFIX=$(VENDORDIR)/libgit2/git2go/static-build/install \
+		-DCMAKE_INSTALL_LIBDIR="lib" \
+		-DDEPRECATE_HARD="${BUILD_DEPRECATE_HARD}" \
+		$(VENDORDIR)/libgit2/git2go/vendor/libgit2)
+	$(MAKE) -C $(VENDORDIR)/libgit2/git2go/static-build/build install
+
+$(VENDORDIR)/libgit2/git2go/vendor/libgit2: $(VENDORDIR)/libgit2/git2go
+	@git -C $(VENDORDIR)/libgit2/git2go submodule update --init --recursive
+
+$(VENDORDIR)/libgit2/git2go:
+	@git clone --branch v31.7.9 --recurse-submodules https://github.com/libgit2/git2go.git $@

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 
 replace (
 	github.com/zclconf/go-cty => github.com/zclconf/go-cty v1.10.0
-	github.com/libgit2/git2go/v31 => github.com/libgit2/git2go/v31 v31.7.9
+	github.com/libgit2/git2go/v31 v31.7.9 => ./third_party/libgit2/git2go
 )
 
 require (


### PR DESCRIPTION
Similar to kraftkit, the plugin needs to have the dependency inside kraftkit to ensure that no errors appear.

This can still happen if the `libssh` or `libssl` versions are missing, but for now it should be good enough.
