### PR TITLE
docs: Adapt docs to new standard for registration

### DIFF
--- a/.copywrite.hcl
+++ b/.copywrite.hcl
@@ -1,0 +1,7 @@
+project {
+  license = "MPL-2.0"
+  copyright_year = 2023
+  header_ignore = [
+   ".goreleaser.yml"
+  ]
+}

--- a/.github/workflows/notify-integration-release-via-manual.yaml
+++ b/.github/workflows/notify-integration-release-via-manual.yaml
@@ -1,0 +1,48 @@
+# Manual release workflow is used for deploying documentation updates
+# on the specified branch without making an official plugin release. 
+name: Notify Integration Release (Manual)
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "The release version (semver)"
+        default: 1.0.0
+        required: false
+      branch:
+        description: "A branch or SHA"
+        default: 'main'
+        required: false
+jobs:
+  notify-release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout this repo
+        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
+        with:
+          ref: ${{ github.event.inputs.branch }}
+      # Ensure that Docs are Compiled
+      - uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
+      - shell: bash
+        run: make generate
+      - shell: bash
+        run: |
+          if [[ -z "$(git status -s)" ]]; then
+            echo "OK"
+          else
+            echo "Docs have been updated, but the compiled docs have not been committed."
+            echo "Run 'make generate', and commit the result to resolve this error."
+            exit 1
+          fi
+      # Perform the Release
+      - name: Checkout integration-release-action
+        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
+        with:
+          repository: hashicorp/integration-release-action
+          path: ./integration-release-action
+      - name: Notify Release
+        uses: ./integration-release-action
+        with:
+          integration_identifier: "packer/unikraft/unikraft"
+          release_version: ${{ github.event.inputs.version }}
+          release_sha: ${{ github.event.inputs.branch }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/notify-integration-release-via-tag.yaml
+++ b/.github/workflows/notify-integration-release-via-tag.yaml
@@ -1,0 +1,52 @@
+name: Notify Integration Release (Tag)
+on:
+  push:
+    tags:
+      - '*.*.*'   # Proper releases
+jobs:
+  strip-version:
+    runs-on: ubuntu-latest
+    outputs:
+      packer-version: ${{ steps.strip.outputs.packer-version }}
+    steps:
+      - name: Strip leading v from version tag
+        id: strip
+        env:
+          REF: ${{ github.ref_name }}
+        run: |
+          echo "packer-version=$(echo "$REF" | sed -E 's/v?([0-9]+\.[0-9]+\.[0-9]+)/\1/')" >> "$GITHUB_OUTPUT"
+  notify-release:
+    needs:
+      - strip-version
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout this repo
+        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
+        with:
+          ref: ${{ github.ref }}
+      # Ensure that Docs are Compiled
+      - uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
+      - shell: bash
+        run: make generate
+      - shell: bash
+        run: |
+          if [[ -z "$(git status -s)" ]]; then
+            echo "OK"
+          else
+            echo "Docs have been updated, but the compiled docs have not been committed."
+            echo "Run 'make generate', and commit the result to resolve this error."
+            exit 1
+          fi
+      # Perform the Release
+      - name: Checkout integration-release-action
+        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
+        with:
+          repository: hashicorp/integration-release-action
+          path: ./integration-release-action
+      - name: Notify Release
+        uses: ./integration-release-action
+        with:
+          integration_identifier: "packer/unikraft/unikraft"
+          release_version: ${{ needs.strip-version.outputs.packer-version }}
+          release_sha: ${{ github.ref }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.web-docs/README.md
+++ b/.web-docs/README.md
@@ -1,0 +1,56 @@
+# Packer Plugin Unikraft
+The `Unikraft` multi-component plugin can be used with HashiCorp [Packer](https://www.packer.io)
+to create custom images. For the full list of available features for this plugin see [docs](docs).
+
+## Installation
+
+### Using pre-built releases
+
+#### Using the `packer init` command
+
+Starting from version 1.7, Packer supports a new `packer init` command allowing
+automatic installation of Packer plugins. Read the
+[Packer documentation](https://www.packer.io/docs/commands/init) for more information.
+
+To install this plugin, copy and paste this code into your Packer configuration.
+Then, run [`packer init`](https://www.packer.io/docs/commands/init).
+
+```hcl
+packer {
+  required_plugins {
+    unikraft = {
+      version = ">= 0.2.0"
+      source  = "github.com/unikraft/unikraft"
+    }
+  }
+}
+```
+
+
+#### Manual installation
+
+You can find pre-built binary releases of the plugin [here](https://github.com/unikraft/packer-plugin-unikraft/releases).
+Once you have downloaded the latest archive corresponding to your target OS,
+uncompress it to retrieve the plugin binary file corresponding to your platform.
+To install the plugin, please follow the Packer documentation on
+[installing a plugin](https://www.packer.io/docs/extending/plugins/#installing-plugins).
+
+
+### From Sources
+
+If you prefer to build the plugin from sources, clone the GitHub repository
+locally and run the command `go build` from the root
+directory. Upon successful compilation, a `packer-plugin-unikraft` plugin
+binary file can be found in the root directory.
+To install the compiled plugin, please follow the official Packer documentation
+on [installing a plugin](https://www.packer.io/docs/extending/plugins/#installing-plugins).
+
+### Components
+
+#### Builders
+
+unikraft - The builder builds Unikraft image using Kraftkit.
+
+#### Post-Processors
+
+unikraft - The post-processor takes build artifacts from the unikraft builder and packages it into an OCI-compatible image.

--- a/.web-docs/components/builder/unikraft/README.md
+++ b/.web-docs/components/builder/unikraft/README.md
@@ -1,0 +1,43 @@
+The builder uses packer version 1.7.0 and up to create pipelines.
+After running the Unikraft builder the end result is one or multiple Unikraft images.
+They are situated in a build directory which is created by the Unikraft build system.
+
+The builder wraps around the `kraftkit` build system which relies on `kraft.yaml` files to define builds.
+Moreover, `kraft` itself wraps over the `kconfig` build system of Unikraft.
+All three together build the images and offer final binaries.
+
+**Required**
+
+- `architecture` (string) - The architecture to build the image for. Example: `x86_64`, `arm64`, `arm`.
+- `platform` (string) - The platform to build the image for. Example: `kvm`, `xen`, `linuxu`.
+- `build_path` (string) - The path to the build directory. This is the directory where the `kraft.yaml` file is located.
+
+**Optional**
+
+- `target` (string) - The name of the image to build.
+- `pull_source` (string) - The name of the application to pull.
+- `workdir` (string) - The path to pull the source to. It's a parent directory of `build_path`.
+- `sources_no_default` (boolean) - Do not pull the default manifest sources. Required when working with custom repositories.
+- `sources` (string list) - The links of the sources to pull.
+- `options` (string) - The options to pass to the build system. Options are separated by spaces and of the format `KEY=value`. Currently disabled.
+- `log_level` (string) - The log level to use. Can be `debug`, `info`, `warn`, `error`, `fatal`, `panic`. Default: `info`.
+
+### Example Usage
+
+
+```hcl
+ source "unikraft-builder" "example" {
+    architecture = "x86_64"
+    platform = "qemu"
+    build_path = "/tmp/test/.unikraft/apps/helloworld"
+    workdir = "/tmp/test"
+    pull_source = "helloworld"
+    sources_no_default = false
+    sources = [ "https://github.com/unikraft/app-helloworld" ]
+    log_level = "info"
+ }
+
+ build {
+   sources = ["source.unikraft-builder.example"]
+ }
+```

--- a/.web-docs/components/post-processor/unikraft/README.md
+++ b/.web-docs/components/post-processor/unikraft/README.md
@@ -1,0 +1,29 @@
+This allows you to export the resulting binary in different formats (e.g. OCI).
+
+**Required**
+
+- `source` (string) - The source directory to create the archive from. The source directory must contain a `kraft.yaml` file.
+- `destination` (string) - The resulting package file. The `destination` must be a valid OCI image name.
+- `architecture` (string) - The architecture of the packaged image.
+- `platform` (string) - The platform of the packaged image.
+
+**Optional**
+
+- `target` (string) - The target of the packaged image.
+- `push` (bool) - If to push the resulting image to the registry.
+- `rootfs` (string) - The path to the rootfs of the packaged image.
+- `log_level` (string) - The log level of the packaged image. Can be `debug`, `info`, `warn`, `error`, `fatal`, `panic`. Default: `info`.
+
+### Example Usage
+
+```hcl
+post-processor "kraft-pkg" {
+  source = "/tmp/example/.unikraft/apps/helloworld"
+  destination = "my-registry.io/helloworld:latest"
+  architecture = "x86_64"
+  platform = "qemu"
+  rootfs = "/tmp/example/.unikraft/apps/helloworld/rootfs"
+  push = true
+  log_level = "info"
+}
+```

--- a/.web-docs/metadata.hcl
+++ b/.web-docs/metadata.hcl
@@ -1,0 +1,25 @@
+# Copyright (c) Unikraft GmbH
+# SPDX-License-Identifier: MPL-2.0
+
+# For full specification on the configuration of this file visit:
+# https://github.com/hashicorp/integration-template#metadata-configuration
+integration {
+  name = "Unikraft"
+  description = "The Unikraft plugin uses kraftkit to create and package runnable Unikraft unikernel images."
+  identifier = "packer/unikraft/unikraft"
+  flags = [ "community" ]
+  license {
+    type = "MPL-2.0"
+    url = "https://github.com/unikraft/packer-plugin-unikraft/blob/main/LICENSE"
+  }
+  component {
+    type = "builder"
+    name = "Unikraft Kraftkit Building"
+    slug = "unikraft"
+  }
+  component {
+    type = "post-processor"
+    name = "Unikraft Kraftkit Packaging"
+    slug = "unikraft"
+  }
+}

--- a/.web-docs/scripts/compile-to-webdocs.sh
+++ b/.web-docs/scripts/compile-to-webdocs.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+
+# Converts the folder name that the component documentation file
+# is stored in into the integration slug of the component.
+componentTypeFromFolderName() {
+    if [[ "$1" = "builders" ]]; then
+        echo "builder"
+    elif [[ "$1" = "provisioners" ]]; then
+        echo "provisioner"
+    elif [[ "$1" = "post-processors" ]]; then
+        echo "post-processor"
+    elif [[ "$1" = "datasources" ]]; then
+        echo "data-source"
+    else
+        echo ""
+    fi
+}
+
+# $1: The content to adjust links
+# $2: The organization of the integration
+rewriteLinks() {
+  local result="$1"
+  local organization="$2"
+
+  urlSegment="([^/]+)"
+  urlAnchor="(#[^/]+)"
+
+  # Rewrite Component Index Page links to the Integration root page.
+  #
+  #                    (\1)     (\2)      (\3)
+  # /packer/plugins/datasources/amazon#anchor-tag-->
+  # /packer/integrations/hashicorp/amazon#anchor-tag
+  local find="\(\/packer\/plugins\/$urlSegment\/$urlSegment$urlAnchor?\)"
+  local replace="\(\/packer\/integrations\/$organization\/\2\3\)"
+  result="$(echo "$result" | sed -E "s/$find/$replace/g")"
+
+
+  # Rewrite Component links to the Integration component page
+  #
+  #                    (\1)      (\2)       (\3)       (\4)
+  # /packer/plugins/datasources/amazon/parameterstore#anchor-tag -->
+  # /packer/integrations/{organization}/amazon/latest/components/datasources/parameterstore
+  local find="\(\/packer\/plugins\/$urlSegment\/$urlSegment\/$urlSegment$urlAnchor?\)"
+  local replace="\(\/packer\/integrations\/$organization\/\2\/latest\/components\/\1\/\3\4\)"
+  result="$(echo "$result" | sed -E "s/$find/$replace/g")"
+
+  # Rewrite the Component URL segment from the Packer Plugin format
+  # to the Integrations format
+  result="$(echo "$result" \
+      | sed "s/\/datasources\//\/data-source\//g" \
+      | sed "s/\/builders\//\/builder\//g" \
+      | sed "s/\/post-processors\//\/post-processor\//g" \
+      | sed "s/\/provisioners\//\/provisioner\//g" \
+  )"
+
+  echo "$result"
+}
+
+# $1: Docs Dir
+# $2: Web Docs Dir
+# $3: Component File
+# $4: The org of the integration
+processComponentFile() {
+    local docsDir="$1"
+    local webDocsDir="$2"
+    local componentFile="$3"
+
+    local escapedDocsDir="$(echo "$docsDir" | sed 's/\//\\\//g' | sed 's/\./\\\./g')"
+    local componentTypeAndSlug="$(echo "$componentFile" | sed "s/$escapedDocsDir\///g" | sed 's/\.mdx//g')"
+
+    # Parse out the Component Slug & Component Type
+    local componentSlug="$(echo "$componentTypeAndSlug" | cut -d'/' -f 2)"
+    local componentType="$(componentTypeFromFolderName "$(echo "$componentTypeAndSlug" | cut -d'/' -f 1)")"
+    if [[ "$componentType" = "" ]]; then
+        echo "Failed to process '$componentFile', unexpected folder name."
+        echo "Documentation for components must be stored in one of:"
+        echo "builders, provisioners, post-processors, datasources"
+        exit 1
+    fi
+
+
+    # Calculate the location of where this file will ultimately go
+    local webDocsFolder="$webDocsDir/components/$componentType/$componentSlug"
+    mkdir -p "$webDocsFolder"
+    local webDocsFile="$webDocsFolder/README.md"
+    local webDocsFileTmp="$webDocsFolder/README.md.tmp"
+
+    # Copy over the file to its webDocsFile location
+    cp "$componentFile" "$webDocsFile"
+
+    # Remove the Header
+    local lastMetadataLine="$(grep -n -m 2 '^\-\-\-' "$componentFile" | tail -n1 | cut -d':' -f1)"
+    cat "$webDocsFile" | tail -n +"$(($lastMetadataLine+2))"  > "$webDocsFileTmp"
+    mv "$webDocsFileTmp" "$webDocsFile"
+
+    # Remove the top H1, as this will be added automatically on the web
+    cat "$webDocsFile" | tail -n +3 > "$webDocsFileTmp"
+    mv "$webDocsFileTmp" "$webDocsFile"
+
+    # Rewrite Links
+    rewriteLinks "$(cat "$webDocsFile")" "$4" > "$webDocsFileTmp"
+    mv "$webDocsFileTmp" "$webDocsFile"
+}
+
+# Compiles the Packer SDC compiled docs folder down
+# to a integrations-compliant folder (web docs)
+#
+# $1: The directory of the plugin
+# $2: The directory of the SDC compiled docs files
+# $3: The output directory to place the web-docs files
+# $4: The org of the integration
+compileWebDocs() {
+  local docsDir="$1/$2"
+  local webDocsDir="$1/$3"
+
+  echo "Compiling MDX docs in '$2' to Markdown in '$3'..."
+  # Create the web-docs directory if it hasn't already been created
+  mkdir -p "$webDocsDir"
+
+  # Copy the README over
+  cp "$docsDir/README.md" "$webDocsDir/README.md"
+
+  # Process all MDX component files (exclude index files, which are unsupported)
+  for file in $(find "$docsDir" | grep "$docsDir/.*/.*\.mdx" | grep --invert-match "index.mdx"); do
+    processComponentFile "$docsDir" "$webDocsDir" "$file" "$4"
+  done
+}
+
+compileWebDocs "$1" "$2" "$3" "$4"

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -37,3 +37,7 @@ testacc: dev
 
 generate: install-packer-sdc
 	@go generate ./...
+	@rm -rf .docs
+	@packer-sdc renderdocs -src docs -partials docs-partials/ -dst .docs/
+	@./.web-docs/scripts/compile-to-webdocs.sh "." ".docs" ".web-docs" "unikraft"
+	@rm -r ".docs"

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,1 +1,56 @@
-../README.md
+# Packer Plugin Unikraft
+The `Unikraft` multi-component plugin can be used with HashiCorp [Packer](https://www.packer.io)
+to create custom images. For the full list of available features for this plugin see [docs](docs).
+
+## Installation
+
+### Using pre-built releases
+
+#### Using the `packer init` command
+
+Starting from version 1.7, Packer supports a new `packer init` command allowing
+automatic installation of Packer plugins. Read the
+[Packer documentation](https://www.packer.io/docs/commands/init) for more information.
+
+To install this plugin, copy and paste this code into your Packer configuration.
+Then, run [`packer init`](https://www.packer.io/docs/commands/init).
+
+```hcl
+packer {
+  required_plugins {
+    unikraft = {
+      version = ">= 0.2.0"
+      source  = "github.com/unikraft/unikraft"
+    }
+  }
+}
+```
+
+
+#### Manual installation
+
+You can find pre-built binary releases of the plugin [here](https://github.com/unikraft/packer-plugin-unikraft/releases).
+Once you have downloaded the latest archive corresponding to your target OS,
+uncompress it to retrieve the plugin binary file corresponding to your platform.
+To install the plugin, please follow the Packer documentation on
+[installing a plugin](https://www.packer.io/docs/extending/plugins/#installing-plugins).
+
+
+### From Sources
+
+If you prefer to build the plugin from sources, clone the GitHub repository
+locally and run the command `go build` from the root
+directory. Upon successful compilation, a `packer-plugin-unikraft` plugin
+binary file can be found in the root directory.
+To install the compiled plugin, please follow the official Packer documentation
+on [installing a plugin](https://www.packer.io/docs/extending/plugins/#installing-plugins).
+
+### Components
+
+#### Builders
+
+unikraft - The builder builds Unikraft image using Kraftkit.
+
+#### Post-Processors
+
+unikraft - The post-processor takes build artifacts from the unikraft builder and packages it into an OCI-compatible image.

--- a/docs/builders/unikraft.mdx
+++ b/docs/builders/unikraft.mdx
@@ -1,12 +1,3 @@
----
-description: >
-  The unikraft builder uses kraftkit to create runnable unikraft unikernel images.
-page_title: Unikraft - Builder
-nav_title: Unikraft
----
-
-# Unikraft
-
 Type: `unikraft`
 
 The Unikraft builder uses kraftkit to create runnable Unikraft unikernel images.
@@ -18,13 +9,13 @@ The builder wraps around the `kraftkit` build system which relies on `kraft.yaml
 Moreover, `kraft` itself wraps over the `kconfig` build system of Unikraft.
 All three together build the images and offer final binaries.
 
-### Required
+**Required**
 
 - `architecture` (string) - The architecture to build the image for. Example: `x86_64`, `arm64`, `arm`.
 - `platform` (string) - The platform to build the image for. Example: `kvm`, `xen`, `linuxu`.
 - `build_path` (string) - The path to the build directory. This is the directory where the `kraft.yaml` file is located.
 
-### Optional
+**Optional**
 
 - `target` (string) - The name of the image to build.
 - `pull_source` (string) - The name of the application to pull.

--- a/docs/post-processors/unikraft.mdx
+++ b/docs/post-processors/unikraft.mdx
@@ -1,27 +1,20 @@
----
-description: >
-  The Packer Unikraft post-processor takes an artifact from the Unikraft builder and packages it into different formats.
-  This allows you to export the resulting binary in different formats (e.g. OCI).
-page_title: Unikraft - Post-Processors
-nav_title: Unikraft
----
-
-# Unikraft Post-Processor
-
 Type: `unikraft`
 
 The Packer Unikraft post-processor takes an artifact from the [Unikraft builder](/packer/plugins/builders/unikraft) and packages it into different formats.
 This allows you to export the resulting binary in different formats (e.g. OCI).
 
-### Required
+**Required**
 
 - `source` (string) - The source directory to create the archive from. The source directory must contain a `kraft.yaml` file.
 - `destination` (string) - The resulting package file. The `destination` must be a valid OCI image name.
-- `architecture` (string) - The architecture of the packaged image. The `architecture` is required.
-- `platform` (string) - The platform of the packaged image. The `platform` is required.
-- `target` (string) - The target of the packaged image. The `target` is optional.
-- `push` (bool) - If to push the resulting image to the registry. `push` is optional.
-- `rootfs` (string) - The path to the rootfs of the packaged image. The `rootfs` is optional.
+- `architecture` (string) - The architecture of the packaged image.
+- `platform` (string) - The platform of the packaged image.
+
+**Optional**
+
+- `target` (string) - The target of the packaged image.
+- `push` (bool) - If to push the resulting image to the registry.
+- `rootfs` (string) - The path to the rootfs of the packaged image.
 - `log_level` (string) - The log level of the packaged image. Can be `debug`, `info`, `warn`, `error`, `fatal`, `panic`. Default: `info`.
 
 ### Example Usage


### PR DESCRIPTION
In the last week the standard for documentation was finalized and we have now a chance to submit the plugin as a community plugin.

This is the checklist for being a valid integration (copied from the issue I will open afterwards):

#### Checklist
- [x] Has valid [`metadata.hcl`](https://github.com/hashicorp/integration-template) file in plugin repository.
- [x] Has added integration scripts [packer-plugin-scaffolding](https://github.com/hashicorp/packer-plugin-scoffolding) to plugin repository.
- [x] Has added top-level integration README.md file to plugin `docs` directory.
- [x] All plugins components have one README.md describing their usage.
- [x] Has a fully synced `.web-docs` directory ready for publishing to the integrations portal.

This translates to having a correct `docs/` and `.web-docs/` directory (`.web-docs/` is generated with `make generate`)

Also this link: <https://developer.hashicorp.com/packer/docs/plugins/creation#registering-plugins>