### PR TITLE
chore: Update metadata.hcl to fix Packer integration ingestion error

### DIFF
--- a/.web-docs/metadata.hcl
+++ b/.web-docs/metadata.hcl
@@ -7,7 +7,6 @@ integration {
   name = "Unikraft"
   description = "The Unikraft plugin uses kraftkit to create and package runnable Unikraft unikernel images."
   identifier = "packer/unikraft/unikraft"
-  flags = [ "community" ]
   license {
     type = "MPL-2.0"
     url = "https://github.com/unikraft/packer-plugin-unikraft/blob/main/LICENSE"


### PR DESCRIPTION
Remove invalid flag to fix integration ingestion errors ad reported in the log below.

```
Updated Integration: packer/unikraft/unikraft
HTTP 404: {"meta":{"status_code":404,"status_text":"Not Found"},"errors":[{"msg":"The specified Flag does not exist"}]}
Exiting "consume-release" script
Failed to add Flag 'community'
```


Once merged you should be able to trigger a release notification job to kick off the ingestion. 